### PR TITLE
Update several versions to latest

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -142,7 +142,7 @@ controller-gen:
 # Download kustomize locally if necessary
 KUSTOMIZE = $(shell pwd)/bin/kustomize
 kustomize:
-	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.8.7)
+	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v4@v4.5.2)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/operator/config/samples/ais_v1beta1_aistore.yaml
+++ b/operator/config/samples/ais_v1beta1_aistore.yaml
@@ -21,14 +21,15 @@ spec:
       - path: "/ais1"
         size: 10Gi
 
-  nodeImage: "aistore/aisnode:3.10"
+    # In certain environments (e.g. minikube), storage volumes attached to AIS targets may not have associated block devices.
+    # Alternatively, AIS targets may "see" multiple mountpath directories sharing a single given block device.
+    # In both of those cases, set allowSharedNoDisks = true (but note that this setting is **not recommended** for production).
+    allowSharedNoDisks: false
+
+
+  nodeImage: "aistore/aisnode:latest"
   initImage: "aistore/ais-init:latest"
   hostpathPrefix: "/etc/ais"
-
-  # In certain environments (e.g. minikube), storage volumes attached to AIS targets may not have associated block devices.
-  # Alternatively, AIS targets may "see" multiple mountpath directories sharing a single given block device.
-  # In both of those cases, set allowSharedNoDisks = true (but note that this setting is **not recommended** for production).
-  allowSharedNoDisks: false
 
   # To be able to access the AIS deployment outside kubernetes cluster, set:
   # enableExternalLB: true

--- a/operator/scripts/deploy.sh
+++ b/operator/scripts/deploy.sh
@@ -5,7 +5,7 @@ release_version=${RELEASE:-v0.5}
 function pre_deploy {
 	read -r -p "would you like to deploy cert-manager? [y/n]" response
     if [[ "${response}" == "y" ]]; then
-        kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.2.0/cert-manager.yaml;
+        kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.9.1/cert-manager.yaml
 
         # Wait for cert-manager to be ready.
         kubectl wait --for=condition=ready pods --all -n cert-manager --timeout=5m;


### PR DESCRIPTION
Noticed a few stale dependencies when trying to spin up AIStore for a test.

`allowSharedNoDisks` was nested at the wrong level in a sample config