### PR TITLE
Modify the resource limit: memory limit from 30Mi to 100Mi

### DIFF
--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -48,7 +48,7 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 100Mi
           requests:
             cpu: 100m
             memory: 20Mi


### PR DESCRIPTION
to resolve issue: https://github.com/NVIDIA/aistore/issues/128

Problem: 
Hit OMM killed of operator controller on my k8s env

Cause:
1. Controller Manager resource limit in mem:30Mi
operator/config/manager/manager.yaml
```

        resources:
          limits:
            cpu: 100m
            memory: 30Mi
          requests:
            cpu: 100m
            memory: 20Mi
```
2. the memory usage average on 55Mi in the cluster.

Solution:
Modify the default memory limit to 100Mi