### PR TITLE
fix: node image incompatible with GKE

### DIFF
--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -6,7 +6,7 @@ provider "google" {
 # Deployment specific variables.
 
 locals {
-  image_type = "ubuntu"
+  image_type = "ubuntu_containerd"
 }
 
 variable "cluster_name" {


### PR DESCRIPTION
GKE v1.24+ doesn't support Docker-based node images.

Currently, when using Terraform to create a GKE K8S cluster, the following error is encountered:
```
╷
│ Error: error creating NodePool: googleapi: Error 400: Creation of node pools using node images based on Docker container runtimes is not supported in GKE v1.24+ clusters as Dockershim has been removed in Kubernetes v1.24., badRequest
│ 
│   with google_container_node_pool.primary_nodes,
│   on main.tf line 86, in resource "google_container_node_pool" "primary_nodes":
│   86: resource "google_container_node_pool" "primary_nodes" {
```