### PR TITLE
Allow configuring PVC retention policy

### DIFF
--- a/operator/api/v1beta1/aistore_types.go
+++ b/operator/api/v1beta1/aistore_types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	aisapc "github.com/NVIDIA/aistore/api/apc"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -561,6 +562,12 @@ type DaemonSpec struct {
 	// HostPort - Port to bind directly to a specific port on the host
 	// +optional
 	HostPort *int32 `json:"hostPort,omitempty"`
+
+	// PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+	// Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+	// Requires Kubernetes 1.32+.
+	// +optional
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy,omitempty"`
 }
 
 type TargetSpec struct {

--- a/operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/operator/api/v1beta1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@ package v1beta1
 
 import (
 	"github.com/NVIDIA/aistore/cmn/cos"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1046,6 +1047,11 @@ func (in *DaemonSpec) DeepCopyInto(out *DaemonSpec) {
 	if in.HostPort != nil {
 		in, out := &in.HostPort, &out.HostPort
 		*out = new(int32)
+		**out = **in
+	}
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
 		**out = **in
 	}
 }

--- a/operator/config/base/crd/ais.nvidia.com_aistores.yaml
+++ b/operator/config/base/crd/ais.nvidia.com_aistores.yaml
@@ -3408,6 +3408,28 @@ spec:
                     description: NodeSelector -  which must match a node's labels
                       for the AIS Daemon pod to be scheduled on that node.
                     type: object
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   portIntraControl:
                     anyOf:
                     - type: integer
@@ -5221,6 +5243,28 @@ spec:
                           or a percentage (e.g. "10%"). Setting to 0 prevents any voluntary evictions.
                           Defaults to 0 if not specified.
                         x-kubernetes-int-or-string: true
+                    type: object
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
                     type: object
                   portIntraControl:
                     anyOf:

--- a/operator/pkg/controllers/common.go
+++ b/operator/pkg/controllers/common.go
@@ -258,6 +258,10 @@ func syncSidecarContainer(desired, current *corev1.PodTemplateSpec) (updated boo
 	return true
 }
 
+func shouldUpdatePVCRetentionPolicy(desired, current *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) bool {
+	return !equality.Semantic.DeepEqual(desired, current)
+}
+
 func (*AIStoreReconciler) isStatefulSetReady(desiredSize int32, ss *appsv1.StatefulSet) bool {
 	specReplicas := *ss.Spec.Replicas
 

--- a/operator/pkg/controllers/proxy_controller.go
+++ b/operator/pkg/controllers/proxy_controller.go
@@ -146,6 +146,15 @@ func (r *AIStoreReconciler) handleProxyState(ctx context.Context, ais *aisv1.AIS
 		}
 	}
 
+	if policyUpdated, policyErr := r.syncProxyPVCRetentionPolicy(ctx, ais, ss); policyErr != nil {
+		return result, policyErr
+	} else if policyUpdated {
+		ss, err = r.k8sClient.GetStatefulSet(ctx, proxySSName)
+		if err != nil {
+			return
+		}
+	}
+
 	err = r.handleProxyRollout(ctx, ais, ss)
 	if err != nil {
 		return
@@ -224,6 +233,22 @@ func (r *AIStoreReconciler) syncProxyPodSpec(ctx context.Context, ais *aisv1.AIS
 	}
 	logger.Info("Statefulset successfully updated", "reason", reason)
 	return
+}
+
+func (r *AIStoreReconciler) syncProxyPVCRetentionPolicy(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) (updated bool, err error) {
+	desiredPolicy := ais.Spec.ProxySpec.PersistentVolumeClaimRetentionPolicy
+	if !shouldUpdatePVCRetentionPolicy(desiredPolicy, ss.Spec.PersistentVolumeClaimRetentionPolicy) {
+		return false, nil
+	}
+	logger := logf.FromContext(ctx).WithValues("statefulset", ss.Name)
+	updatedSS := ss.DeepCopy()
+	updatedSS.Spec.PersistentVolumeClaimRetentionPolicy = desiredPolicy
+	patch := client.MergeFrom(ss)
+	if err = r.k8sClient.Patch(ctx, updatedSS, patch); err != nil {
+		return false, err
+	}
+	logger.Info("Updated proxy PVC retention policy")
+	return true, nil
 }
 
 func (r *AIStoreReconciler) handleProxyRollout(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) error {

--- a/operator/pkg/controllers/target_controllers.go
+++ b/operator/pkg/controllers/target_controllers.go
@@ -137,6 +137,12 @@ func (r *AIStoreReconciler) handleTargetState(ctx context.Context, ais *aisv1.AI
 		return ctrl.Result{RequeueAfter: targetLongRequeueDelay}, nil
 	}
 
+	if policyUpdated, policyErr := r.syncTargetPVCRetentionPolicy(ctx, ais, ss); policyErr != nil {
+		return ctrl.Result{}, policyErr
+	} else if policyUpdated {
+		return ctrl.Result{RequeueAfter: targetLongRequeueDelay}, nil
+	}
+
 	if result, err := r.handleTargetRollout(ctx, ais, ss); err != nil || !result.IsZero() {
 		return result, err
 	}
@@ -312,6 +318,22 @@ func (r *AIStoreReconciler) syncTargetPodSpec(ctx context.Context, ais *aisv1.AI
 		return true, err
 	}
 	return false, nil
+}
+
+func (r *AIStoreReconciler) syncTargetPVCRetentionPolicy(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) (updated bool, err error) {
+	desiredPolicy := ais.Spec.TargetSpec.PersistentVolumeClaimRetentionPolicy
+	if !shouldUpdatePVCRetentionPolicy(desiredPolicy, ss.Spec.PersistentVolumeClaimRetentionPolicy) {
+		return false, nil
+	}
+	logger := logf.FromContext(ctx).WithValues("statefulset", ss.Name)
+	updatedSS := ss.DeepCopy()
+	updatedSS.Spec.PersistentVolumeClaimRetentionPolicy = desiredPolicy
+	patch := client.MergeFrom(ss)
+	if err = r.k8sClient.Patch(ctx, updatedSS, patch); err != nil {
+		return false, err
+	}
+	logger.Info("Updated target PVC retention policy")
+	return true, nil
 }
 
 func isPodActive(pod *corev1.Pod) bool {

--- a/operator/pkg/resources/proxy/statefulset.go
+++ b/operator/pkg/resources/proxy/statefulset.go
@@ -60,7 +60,7 @@ func NewProxyStatefulSet(ais *aisv1.AIStore, size int32) *apiv1.StatefulSet {
 	maps.Copy(podLabels, basicLabels)
 	maps.Copy(podLabels, ais.Spec.ProxySpec.Labels)
 
-	return &apiv1.StatefulSet{
+	ss := &apiv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ais.ProxyStatefulSetName(),
 			Namespace: ais.Namespace,
@@ -83,6 +83,10 @@ func NewProxyStatefulSet(ais *aisv1.AIStore, size int32) *apiv1.StatefulSet {
 			},
 		},
 	}
+	if ais.Spec.ProxySpec.PersistentVolumeClaimRetentionPolicy != nil {
+		ss.Spec.PersistentVolumeClaimRetentionPolicy = ais.Spec.ProxySpec.PersistentVolumeClaimRetentionPolicy
+	}
+	return ss
 }
 
 /////////////////

--- a/operator/pkg/resources/target/statefulset.go
+++ b/operator/pkg/resources/target/statefulset.go
@@ -52,7 +52,7 @@ func NewTargetSS(ais *aisv1.AIStore, expectedSize int32) *apiv1.StatefulSet {
 	maps.Copy(podLabels, BasicLabels(ais))
 	maps.Copy(podLabels, ais.Spec.TargetSpec.Labels)
 
-	return &apiv1.StatefulSet{
+	ss := &apiv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        statefulSetName(ais),
 			Namespace:   ais.Namespace,
@@ -79,6 +79,10 @@ func NewTargetSS(ais *aisv1.AIStore, expectedSize int32) *apiv1.StatefulSet {
 			},
 		},
 	}
+	if ais.Spec.TargetSpec.PersistentVolumeClaimRetentionPolicy != nil {
+		ss.Spec.PersistentVolumeClaimRetentionPolicy = ais.Spec.TargetSpec.PersistentVolumeClaimRetentionPolicy
+	}
+	return ss
 }
 
 func targetPodSpec(ais *aisv1.AIStore) *corev1.PodSpec {

--- a/operator/pkg/resources/target/statefulset_test.go
+++ b/operator/pkg/resources/target/statefulset_test.go
@@ -12,6 +12,7 @@ import (
 	aisv1 "github.com/ais-operator/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +144,36 @@ var _ = Describe("Statefulset Target Volumes and Mounts", Label("short"), func()
 			Expect(*dataVolume.HostPath.Type).To(Equal(v1.HostPathDirectoryOrCreate))
 
 			Expect(result.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(5))
+		})
+	})
+
+	Describe("PVCRetentionPolicy", func() {
+		It("should not set PersistentVolumeClaimRetentionPolicy when nil", func() {
+			specCopy := aisSpec.DeepCopy()
+			specCopy.Spec.TargetSpec.Mounts = []aisv1.Mount{{
+				Path:         "/data/test",
+				Size:         size,
+				StorageClass: apc.Ptr("dataStorageClass"),
+			}}
+			result := NewTargetSS(specCopy, *specCopy.Spec.Size)
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy).To(BeNil())
+		})
+
+		It("should set PersistentVolumeClaimRetentionPolicy when specified", func() {
+			specCopy := aisSpec.DeepCopy()
+			specCopy.Spec.TargetSpec.Mounts = []aisv1.Mount{{
+				Path:         "/data/test",
+				Size:         size,
+				StorageClass: apc.Ptr("dataStorageClass"),
+			}}
+			specCopy.Spec.TargetSpec.PersistentVolumeClaimRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			}
+			result := NewTargetSS(specCopy, *specCopy.Spec.Size)
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy).ToNot(BeNil())
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted).To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled).To(Equal(appsv1.RetainPersistentVolumeClaimRetentionPolicyType))
 		})
 	})
 })


### PR DESCRIPTION
We run AIStore on the same nodes running our ML workloads, meaning we run it on GPU nodes which often need to be taken out of service for repairs. This is kind of annoying to do right now because the PVCs from scaled-down replicas don't get deleted. If we have a cluster of nodes A and B, we scale down B, and then scale up another node C then AIStore will fail to run on node C until we clean up the stale data in the PVC.

This adds support in the `AIStore` CRD for configuring the `persistentVolumeClaimRetentionPolicy` ([docs](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)) so that PVCs get deleted when scaling down.