### PR TITLE
Allow configuring PVC retention policy

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -24,6 +24,7 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
 - Restricted security context for init and logSidecar containers
 - Native support for arm64 hosts with multi-arch container image build targets 
 - Added `operator_state.md` documenting the cluster lifecycle states
+- `spec.proxySpec.pvcRetentionPolicy` and `spec.targetSpec.pvcRetentionPolicy` for configuring retention policies for persistent volume claims.
 
 ## v2.14.0
 

--- a/operator/api/v1beta1/aistore_types.go
+++ b/operator/api/v1beta1/aistore_types.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	aisapc "github.com/NVIDIA/aistore/api/apc"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -559,6 +560,12 @@ type DaemonSpec struct {
 	// HostPort - Port to bind directly to a specific port on the host
 	// +optional
 	HostPort *int32 `json:"hostPort,omitempty"`
+
+	// PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+	// Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+	// Requires Kubernetes 1.32+.
+	// +optional
+	PVCRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"pvcRetentionPolicy,omitempty"`
 }
 
 type TargetSpec struct {

--- a/operator/api/v1beta1/aistore_webhook.go
+++ b/operator/api/v1beta1/aistore_webhook.go
@@ -200,6 +200,7 @@ func validateProxyUpdate(prev, ais *AIStore) error {
 	prev.Spec.ProxySpec.Resources = ais.Spec.ProxySpec.Resources
 	prev.Spec.ProxySpec.SecurityContext = ais.Spec.ProxySpec.SecurityContext
 	prev.Spec.ProxySpec.AutoScaleConf = ais.Spec.ProxySpec.AutoScaleConf
+	prev.Spec.ProxySpec.PVCRetentionPolicy = ais.Spec.ProxySpec.PVCRetentionPolicy
 	if !equality.Semantic.DeepEqual(ais.Spec.ProxySpec, prev.Spec.ProxySpec) {
 		diff := deep.Equal(ais.Spec.ProxySpec, prev.Spec.ProxySpec)
 		webhooklog.Info(fmt.Sprintf("Differences found in proxy spec: [%s]", strings.Join(diff, ", ")))
@@ -218,6 +219,7 @@ func validateTargetUpdate(prev, ais *AIStore) error {
 	prev.Spec.TargetSpec.SecurityContext = ais.Spec.TargetSpec.SecurityContext
 	prev.Spec.TargetSpec.AutoScaleConf = ais.Spec.TargetSpec.AutoScaleConf
 	prev.Spec.TargetSpec.PodDisruptionBudget = ais.Spec.TargetSpec.PodDisruptionBudget
+	prev.Spec.TargetSpec.PVCRetentionPolicy = ais.Spec.TargetSpec.PVCRetentionPolicy
 	if !equality.Semantic.DeepEqual(ais.Spec.TargetSpec, prev.Spec.TargetSpec) {
 		diff := deep.Equal(ais.Spec.TargetSpec, prev.Spec.TargetSpec)
 		webhooklog.Info(fmt.Sprintf("Differences found in target spec: [%s]", strings.Join(diff, ", ")))

--- a/operator/api/v1beta1/zz_generated.deepcopy.go
+++ b/operator/api/v1beta1/zz_generated.deepcopy.go
@@ -10,6 +10,7 @@ package v1beta1
 
 import (
 	"github.com/NVIDIA/aistore/cmn/cos"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -1046,6 +1047,11 @@ func (in *DaemonSpec) DeepCopyInto(out *DaemonSpec) {
 	if in.HostPort != nil {
 		in, out := &in.HostPort, &out.HostPort
 		*out = new(int32)
+		**out = **in
+	}
+	if in.PVCRetentionPolicy != nil {
+		in, out := &in.PVCRetentionPolicy, &out.PVCRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
 		**out = **in
 	}
 }

--- a/operator/config/base/crd/ais.nvidia.com_aistores.yaml
+++ b/operator/config/base/crd/ais.nvidia.com_aistores.yaml
@@ -3423,6 +3423,28 @@ spec:
                     - type: integer
                     - type: string
                     x-kubernetes-int-or-string: true
+                  pvcRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   resources:
                     description: |-
                       Compute Resources required by AIStore daemon pods.
@@ -5237,6 +5259,28 @@ spec:
                     - type: integer
                     - type: string
                     x-kubernetes-int-or-string: true
+                  pvcRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   resources:
                     description: |-
                       Compute Resources required by AIStore daemon pods.

--- a/operator/helm/ais-operator/templates/aistore-crd.yaml
+++ b/operator/helm/ais-operator/templates/aistore-crd.yaml
@@ -3421,6 +3421,28 @@ spec:
                     - type: integer
                     - type: string
                     x-kubernetes-int-or-string: true
+                  pvcRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   resources:
                     description: |-
                       Compute Resources required by AIStore daemon pods.
@@ -5228,6 +5250,28 @@ spec:
                     - type: integer
                     - type: string
                     x-kubernetes-int-or-string: true
+                  pvcRetentionPolicy:
+                    description: |-
+                      PVCRetentionPolicy defines the PVC retention policy for the StatefulSet.
+                      Controls whether PVCs are retained or deleted when pods are scaled down or the StatefulSet is deleted.
+                      Requires Kubernetes 1.32+.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   resources:
                     description: |-
                       Compute Resources required by AIStore daemon pods.

--- a/operator/pkg/controllers/cluster_controller_test.go
+++ b/operator/pkg/controllers/cluster_controller_test.go
@@ -822,6 +822,59 @@ var _ = Describe("AIStoreController", func() {
 			),
 		)
 	})
+	Describe("shouldUpdatePVCRetentionPolicy", func() {
+		DescribeTable("should correctly compare PVC retention policy", func(desiredSyncPolicy, currentSyncPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy, expectedResult bool) {
+			needsUpdate := shouldUpdatePVCRetentionPolicy(desiredSyncPolicy, currentSyncPolicy)
+			Expect(needsUpdate).To(Equal(expectedResult))
+		},
+			Entry("desired policy nil, current policy nil",
+				nil,
+				nil,
+				false,
+			),
+			Entry("desired policy nil, current policy default value",
+				nil,
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+				},
+				false,
+			),
+			Entry("desired policy set, current policy nil",
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+				nil,
+				// This case happens if the kubernetes control plane is too old to support StatefulSet PVC retention policies.
+				// We'll still try to set the field in this case, which will cause an error and make it apparent to the user that
+				// they need to update kubernetes.
+				true,
+			),
+			Entry("desired policy == current policy",
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+				false,
+			),
+			Entry("desired policy != current policy",
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+				&appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+					WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+					WhenScaled:  appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				},
+				true,
+			),
+		)
+	})
 })
 
 func statefulSetsImagesLatest(ctx context.Context, c client.Client, ais *aisv1.AIStore) func(g Gomega) {

--- a/operator/pkg/controllers/common.go
+++ b/operator/pkg/controllers/common.go
@@ -318,6 +318,15 @@ func isPodInCrashLoopBackOff(pod *corev1.Pod) bool {
 	return false
 }
 
+func shouldUpdatePVCRetentionPolicy(desired, current *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy) bool {
+	// If desired is unset then we want current to be either unset or the default value.
+	if desired == nil {
+		return current != nil && (current.WhenDeleted != appsv1.RetainPersistentVolumeClaimRetentionPolicyType || current.WhenScaled != appsv1.RetainPersistentVolumeClaimRetentionPolicyType)
+	}
+
+	return !equality.Semantic.DeepEqual(desired, current)
+}
+
 func (*AIStoreReconciler) isStatefulSetReady(desiredSize int32, ss *appsv1.StatefulSet) bool {
 	specReplicas := *ss.Spec.Replicas
 

--- a/operator/pkg/controllers/proxy_controller.go
+++ b/operator/pkg/controllers/proxy_controller.go
@@ -155,6 +155,16 @@ func (r *AIStoreReconciler) handleProxyState(ctx context.Context, ais *aisv1.AIS
 			return ctrl.Result{RequeueAfter: proxyStartupInterval}, nil
 		}
 	}
+
+	if policyUpdated, policyErr := r.syncProxyPVCRetentionPolicy(ctx, ais, ss); policyErr != nil {
+		return result, policyErr
+	} else if policyUpdated {
+		ss, err = r.k8sClient.GetStatefulSet(ctx, proxySSName)
+		if err != nil {
+			return
+		}
+	}
+
 	// Apply scaling (blocked by rollout in progress)
 	if scalingNeeded && !rolling {
 		if err = r.handleProxyScale(ctx, ais, ss); err != nil {
@@ -239,6 +249,22 @@ func (r *AIStoreReconciler) syncProxyPodSpec(ctx context.Context, ais *aisv1.AIS
 	}
 	logger.Info("Statefulset successfully updated", "reason", reason)
 	return
+}
+
+func (r *AIStoreReconciler) syncProxyPVCRetentionPolicy(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) (updated bool, err error) {
+	desiredPolicy := ais.Spec.ProxySpec.PVCRetentionPolicy
+	if !shouldUpdatePVCRetentionPolicy(desiredPolicy, ss.Spec.PersistentVolumeClaimRetentionPolicy) {
+		return false, nil
+	}
+	logger := logf.FromContext(ctx).WithValues("statefulset", ss.Name)
+	updatedSS := ss.DeepCopy()
+	updatedSS.Spec.PersistentVolumeClaimRetentionPolicy = desiredPolicy
+	patch := client.MergeFrom(ss)
+	if err = r.k8sClient.Patch(ctx, updatedSS, patch); err != nil {
+		return false, err
+	}
+	logger.Info("Updated proxy PVC retention policy")
+	return true, nil
 }
 
 func (r *AIStoreReconciler) handleProxyRollout(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) error {

--- a/operator/pkg/controllers/target_controllers.go
+++ b/operator/pkg/controllers/target_controllers.go
@@ -136,6 +136,15 @@ func (r *AIStoreReconciler) handleTargetState(ctx context.Context, ais *aisv1.AI
 		"rolloutNeeded", rolloutNeeded, "scalingNeeded", scalingNeeded,
 	)
 
+	if policyUpdated, policyErr := r.syncTargetPVCRetentionPolicy(ctx, ais, ss); policyErr != nil {
+		return ctrl.Result{}, policyErr
+	} else if policyUpdated {
+		ss, err = r.k8sClient.GetStatefulSet(ctx, target.StatefulSetNSName(ais))
+		if err != nil {
+			return
+		}
+	}
+
 	// Apply template update (blocked by scaling in progress)
 	if rolloutNeeded && !scaling {
 		if updated, err := r.syncTargetPodSpec(ctx, ais, ss); err != nil {
@@ -338,6 +347,22 @@ func (r *AIStoreReconciler) syncTargetPodSpec(ctx context.Context, ais *aisv1.AI
 		return true, err
 	}
 	return false, nil
+}
+
+func (r *AIStoreReconciler) syncTargetPVCRetentionPolicy(ctx context.Context, ais *aisv1.AIStore, ss *appsv1.StatefulSet) (updated bool, err error) {
+	desiredPolicy := ais.Spec.TargetSpec.PVCRetentionPolicy
+	if !shouldUpdatePVCRetentionPolicy(desiredPolicy, ss.Spec.PersistentVolumeClaimRetentionPolicy) {
+		return false, nil
+	}
+	logger := logf.FromContext(ctx).WithValues("statefulset", ss.Name)
+	updatedSS := ss.DeepCopy()
+	updatedSS.Spec.PersistentVolumeClaimRetentionPolicy = desiredPolicy
+	patch := client.MergeFrom(ss)
+	if err = r.k8sClient.Patch(ctx, updatedSS, patch); err != nil {
+		return false, err
+	}
+	logger.Info("Updated target PVC retention policy")
+	return true, nil
 }
 
 func isPodActive(pod *corev1.Pod) bool {

--- a/operator/pkg/resources/proxy/statefulset.go
+++ b/operator/pkg/resources/proxy/statefulset.go
@@ -60,7 +60,7 @@ func NewProxyStatefulSet(ais *aisv1.AIStore, size int32) *apiv1.StatefulSet {
 	maps.Copy(podLabels, basicLabels)
 	maps.Copy(podLabels, ais.Spec.ProxySpec.Labels)
 
-	return &apiv1.StatefulSet{
+	ss := &apiv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ais.ProxyStatefulSetName(),
 			Namespace: ais.Namespace,
@@ -83,6 +83,10 @@ func NewProxyStatefulSet(ais *aisv1.AIStore, size int32) *apiv1.StatefulSet {
 			},
 		},
 	}
+	if ais.Spec.ProxySpec.PVCRetentionPolicy != nil {
+		ss.Spec.PersistentVolumeClaimRetentionPolicy = ais.Spec.ProxySpec.PVCRetentionPolicy
+	}
+	return ss
 }
 
 /////////////////

--- a/operator/pkg/resources/target/statefulset.go
+++ b/operator/pkg/resources/target/statefulset.go
@@ -52,7 +52,7 @@ func NewTargetSS(ais *aisv1.AIStore, expectedSize int32) *apiv1.StatefulSet {
 	maps.Copy(podLabels, BasicLabels(ais))
 	maps.Copy(podLabels, ais.Spec.TargetSpec.Labels)
 
-	return &apiv1.StatefulSet{
+	ss := &apiv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        statefulSetName(ais),
 			Namespace:   ais.Namespace,
@@ -79,6 +79,10 @@ func NewTargetSS(ais *aisv1.AIStore, expectedSize int32) *apiv1.StatefulSet {
 			},
 		},
 	}
+	if ais.Spec.TargetSpec.PVCRetentionPolicy != nil {
+		ss.Spec.PersistentVolumeClaimRetentionPolicy = ais.Spec.TargetSpec.PVCRetentionPolicy
+	}
+	return ss
 }
 
 func targetPodSpec(ais *aisv1.AIStore) *corev1.PodSpec {

--- a/operator/pkg/resources/target/statefulset_test.go
+++ b/operator/pkg/resources/target/statefulset_test.go
@@ -12,6 +12,7 @@ import (
 	aisv1 "github.com/ais-operator/api/v1beta1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -143,6 +144,36 @@ var _ = Describe("Statefulset Target Volumes and Mounts", Label("short"), func()
 			Expect(*dataVolume.HostPath.Type).To(Equal(v1.HostPathDirectoryOrCreate))
 
 			Expect(result.Spec.Template.Spec.Containers[0].VolumeMounts).To(HaveLen(5))
+		})
+	})
+
+	Describe("PVCRetentionPolicy", func() {
+		It("should not set PersistentVolumeClaimRetentionPolicy when nil", func() {
+			specCopy := aisSpec.DeepCopy()
+			specCopy.Spec.TargetSpec.Mounts = []aisv1.Mount{{
+				Path:         "/data/test",
+				Size:         size,
+				StorageClass: apc.Ptr("dataStorageClass"),
+			}}
+			result := NewTargetSS(specCopy, *specCopy.Spec.Size)
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy).To(BeNil())
+		})
+
+		It("should set PersistentVolumeClaimRetentionPolicy when specified", func() {
+			specCopy := aisSpec.DeepCopy()
+			specCopy.Spec.TargetSpec.Mounts = []aisv1.Mount{{
+				Path:         "/data/test",
+				Size:         size,
+				StorageClass: apc.Ptr("dataStorageClass"),
+			}}
+			specCopy.Spec.TargetSpec.PVCRetentionPolicy = &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+				WhenDeleted: appsv1.DeletePersistentVolumeClaimRetentionPolicyType,
+				WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			}
+			result := NewTargetSS(specCopy, *specCopy.Spec.Size)
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy).ToNot(BeNil())
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy.WhenDeleted).To(Equal(appsv1.DeletePersistentVolumeClaimRetentionPolicyType))
+			Expect(result.Spec.PersistentVolumeClaimRetentionPolicy.WhenScaled).To(Equal(appsv1.RetainPersistentVolumeClaimRetentionPolicyType))
 		})
 	})
 })


### PR DESCRIPTION
We run AIStore on the same nodes running our ML workloads, meaning we run it on GPU nodes which often need to be taken out of service for repairs. This is kind of annoying to do right now because the PVCs from scaled-down replicas don't get deleted. If we have a cluster of nodes A and B, we scale down B, and then scale up another node C then AIStore will fail to run on node C until we clean up the stale data in the PVC.

This adds support in the AIStore CRD for configuring the persistentVolumeClaimRetentionPolicy ([docs](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#persistentvolumeclaim-retention)) so that PVCs get deleted when scaling down.