### PR TITLE
helm/authn: make HMAC key optional

### DIFF
--- a/helm/authn/charts/authn/templates/resources.yaml
+++ b/helm/authn/charts/authn/templates/resources.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.signing.method "hmac" }}
+{{- if and (eq .Values.signing.method "hmac") .Values.signing.key }}
 ---
 # K8s Secret with the HMAC JWT signing key
 apiVersion: v1


### PR DESCRIPTION
We want to manage secrets using an operator, so they aren't committed into our argocd manifests repo. This is currently a little hacky because the authn helm chart always renders the HMAC key secret, so this adds an if statement so it's skipped if the key is empty.