### PR TITLE
helm/authn: support setting imagePullSecrets

### DIFF
--- a/helm/authn/charts/authn/Chart.yaml
+++ b/helm/authn/charts/authn/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
 name: authn
 description: AIS Authentication Server
-version: 0.4.0
+version: 0.5.0
 appVersion: v4.4

--- a/helm/authn/charts/authn/templates/deployment.yaml
+++ b/helm/authn/charts/authn/templates/deployment.yaml
@@ -21,6 +21,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: {{ .Chart.Name }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/helm/authn/charts/authn/values.schema.json
+++ b/helm/authn/charts/authn/values.schema.json
@@ -261,6 +261,17 @@
         }
       }
     },
+    "imagePullSecrets": {
+      "type": "array",
+      "description": "List of image pull secrets for private registries",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" }
+        },
+        "required": ["name"]
+      }
+    },
     "podSecurityContext": {
       "type": "object",
       "description": "Pod-level security context"

--- a/helm/authn/helmfile.yaml
+++ b/helm/authn/helmfile.yaml
@@ -51,7 +51,7 @@ releases:
     namespace: ais
     createNamespace: true
     chart: charts/authn
-    version: 0.4.0
+    version: 0.5.0
     values:
       - "./charts/authn/values.yaml.gotmpl"
       - "{{ .Environment.Values.valuesPath }}"


### PR DESCRIPTION
I'd like to pull the authn image from an internal mirror, so this adds support for setting `imagePullSecrets` in the authn helm chart.