### PR TITLE
helm/authn: make hmac key not required in signing config

### DIFF
--- a/helm/authn/charts/authn/values.schema.json
+++ b/helm/authn/charts/authn/values.schema.json
@@ -62,15 +62,7 @@
           "description": "Optional passphrase for encrypting the RSA private key on disk"
         }
       },
-      "required": ["method"],
-      "if": {
-        "properties": { "method": { "const": "hmac" } }
-      },
-      "then": {
-        "properties": {
-          "key": { "type": "string", "minLength": 12 }
-        }
-      }
+      "required": ["method"]
     },
     "auth": {
       "type": "object",


### PR DESCRIPTION
I forgot to update the helm schema in https://github.com/NVIDIA/ais-k8s/pull/49 to make the hmac key not required in the helm chart.