### PR TITLE
operator: allow updates to tolerations

### DIFF
--- a/operator/api/v1beta1/aistore_webhook.go
+++ b/operator/api/v1beta1/aistore_webhook.go
@@ -224,6 +224,7 @@ func validateProxyUpdate(prev, ais *AIStore) error {
 	prev.Spec.ProxySpec.AutoScaleConf = ais.Spec.ProxySpec.AutoScaleConf
 	prev.Spec.ProxySpec.PVCRetentionPolicy = ais.Spec.ProxySpec.PVCRetentionPolicy
 	prev.Spec.ProxySpec.Probes = ais.Spec.ProxySpec.Probes
+	prev.Spec.ProxySpec.Tolerations = ais.Spec.ProxySpec.Tolerations
 	if !equality.Semantic.DeepEqual(ais.Spec.ProxySpec, prev.Spec.ProxySpec) {
 		diff := deep.Equal(ais.Spec.ProxySpec, prev.Spec.ProxySpec)
 		webhooklog.Info(fmt.Sprintf("Differences found in proxy spec: [%s]", strings.Join(diff, ", ")))
@@ -244,6 +245,7 @@ func validateTargetUpdate(prev, ais *AIStore) error {
 	prev.Spec.TargetSpec.PodDisruptionBudget = ais.Spec.TargetSpec.PodDisruptionBudget
 	prev.Spec.TargetSpec.PVCRetentionPolicy = ais.Spec.TargetSpec.PVCRetentionPolicy
 	prev.Spec.TargetSpec.Probes = ais.Spec.TargetSpec.Probes
+	prev.Spec.TargetSpec.Tolerations = ais.Spec.TargetSpec.Tolerations
 	if !equality.Semantic.DeepEqual(ais.Spec.TargetSpec, prev.Spec.TargetSpec) {
 		diff := deep.Equal(ais.Spec.TargetSpec, prev.Spec.TargetSpec)
 		webhooklog.Info(fmt.Sprintf("Differences found in target spec: [%s]", strings.Join(diff, ", ")))

--- a/operator/api/v1beta1/aistore_webhook_test.go
+++ b/operator/api/v1beta1/aistore_webhook_test.go
@@ -9,8 +9,69 @@ import (
 
 	aisapc "github.com/NVIDIA/aistore/api/apc"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
+
+func TestValidateProxyUpdateTolerations(t *testing.T) {
+	RegisterTestingT(t)
+
+	toleration := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+
+	t.Run("adding toleration to proxy spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		ais := &AIStore{}
+		ais.Spec.ProxySpec.Tolerations = []corev1.Toleration{toleration}
+		Expect(validateProxyUpdate(prev, ais)).To(Succeed())
+	})
+
+	t.Run("removing toleration from proxy spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		prev.Spec.ProxySpec.Tolerations = []corev1.Toleration{toleration}
+		ais := &AIStore{}
+		Expect(validateProxyUpdate(prev, ais)).To(Succeed())
+	})
+
+	t.Run("modifying toleration in proxy spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		prev.Spec.ProxySpec.Tolerations = []corev1.Toleration{toleration}
+		ais := &AIStore{}
+		modified := toleration
+		modified.Effect = corev1.TaintEffectNoExecute
+		ais.Spec.ProxySpec.Tolerations = []corev1.Toleration{modified}
+		Expect(validateProxyUpdate(prev, ais)).To(Succeed())
+	})
+}
+
+func TestValidateTargetUpdateTolerations(t *testing.T) {
+	RegisterTestingT(t)
+
+	toleration := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+
+	t.Run("adding toleration to target spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		ais := &AIStore{}
+		ais.Spec.TargetSpec.Tolerations = []corev1.Toleration{toleration}
+		Expect(validateTargetUpdate(prev, ais)).To(Succeed())
+	})
+
+	t.Run("removing toleration from target spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		prev.Spec.TargetSpec.Tolerations = []corev1.Toleration{toleration}
+		ais := &AIStore{}
+		Expect(validateTargetUpdate(prev, ais)).To(Succeed())
+	})
+
+	t.Run("modifying toleration in target spec is allowed", func(_ *testing.T) {
+		prev := &AIStore{}
+		prev.Spec.TargetSpec.Tolerations = []corev1.Toleration{toleration}
+		ais := &AIStore{}
+		modified := toleration
+		modified.Effect = corev1.TaintEffectNoExecute
+		ais.Spec.TargetSpec.Tolerations = []corev1.Toleration{modified}
+		Expect(validateTargetUpdate(prev, ais)).To(Succeed())
+	})
+}
 
 func TestAIStoreValidateSize(t *testing.T) {
 	tests := []struct {

--- a/operator/pkg/controllers/common.go
+++ b/operator/pkg/controllers/common.go
@@ -42,6 +42,7 @@ func shouldUpdatePodTemplate(desired, current *corev1.PodTemplateSpec) (bool, st
 		shouldUpdateLabels,
 		shouldUpdateVolumes,
 		shouldUpdatePriorityClass,
+		shouldUpdateTolerations,
 	}
 	return shouldUpdate(desired, current, checks...)
 }
@@ -275,6 +276,13 @@ func shouldUpdatePriorityClass(desired, current *corev1.PodTemplateSpec) (bool, 
 	return false, ""
 }
 
+func shouldUpdateTolerations(desired, current *corev1.PodTemplateSpec) (bool, string) {
+	if !equality.Semantic.DeepEqual(desired.Spec.Tolerations, current.Spec.Tolerations) {
+		return true, "updating tolerations"
+	}
+	return false, ""
+}
+
 func syncPodTemplate(desired, current *corev1.PodTemplateSpec) (updated bool) {
 	for _, daemon := range []struct {
 		desiredContainer *corev1.Container
@@ -315,6 +323,11 @@ func syncPodTemplate(desired, current *corev1.PodTemplateSpec) (updated bool) {
 
 	if desired.Spec.PriorityClassName != current.Spec.PriorityClassName {
 		current.Spec.PriorityClassName = desired.Spec.PriorityClassName
+		updated = true
+	}
+
+	if !equality.Semantic.DeepEqual(desired.Spec.Tolerations, current.Spec.Tolerations) {
+		current.Spec.Tolerations = desired.Spec.Tolerations
 		updated = true
 	}
 

--- a/operator/pkg/controllers/common_test.go
+++ b/operator/pkg/controllers/common_test.go
@@ -398,6 +398,56 @@ var _ = Describe("findAISNodeByPodName", func() {
 	})
 })
 
+var _ = Describe("shouldUpdateTolerations", func() {
+	makePodTemplate := func(tolerations []corev1.Toleration) *corev1.PodTemplateSpec {
+		pt := &corev1.PodTemplateSpec{}
+		pt.Spec.Tolerations = tolerations
+		return pt
+	}
+
+	It("returns false when both have no tolerations", func() {
+		desired := makePodTemplate(nil)
+		current := makePodTemplate(nil)
+		update, _ := shouldUpdateTolerations(desired, current)
+		Expect(update).To(BeFalse())
+	})
+
+	It("returns true when a toleration is added", func() {
+		tol := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+		desired := makePodTemplate([]corev1.Toleration{tol})
+		current := makePodTemplate(nil)
+		update, reason := shouldUpdateTolerations(desired, current)
+		Expect(update).To(BeTrue())
+		Expect(reason).To(Equal("updating tolerations"))
+	})
+
+	It("returns true when a toleration is removed", func() {
+		tol := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+		desired := makePodTemplate(nil)
+		current := makePodTemplate([]corev1.Toleration{tol})
+		update, _ := shouldUpdateTolerations(desired, current)
+		Expect(update).To(BeTrue())
+	})
+
+	It("returns true when a toleration is modified", func() {
+		tol := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+		modified := tol
+		modified.Effect = corev1.TaintEffectNoExecute
+		desired := makePodTemplate([]corev1.Toleration{modified})
+		current := makePodTemplate([]corev1.Toleration{tol})
+		update, _ := shouldUpdateTolerations(desired, current)
+		Expect(update).To(BeTrue())
+	})
+
+	It("returns false when tolerations are identical", func() {
+		tol := corev1.Toleration{Key: "gpu", Operator: corev1.TolerationOpExists, Effect: corev1.TaintEffectNoSchedule}
+		desired := makePodTemplate([]corev1.Toleration{tol})
+		current := makePodTemplate([]corev1.Toleration{tol})
+		update, _ := shouldUpdateTolerations(desired, current)
+		Expect(update).To(BeFalse())
+	})
+})
+
 var _ = Describe("hostnameMatchesPod", func() {
 	DescribeTable("matches only when the hostname's first label equals the pod name",
 		func(hostname, podName string, expected bool) {


### PR DESCRIPTION
I would like to update tolerations on the ais-proxy and ais-target pods, but updates to these fields aren't supported. This adds support for updating them.