### PR TITLE
operator: add flag to skip decommission on scale down

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -14,6 +14,7 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
 
 - The operator-managed `AIStoreAuth` reconciliation now generates an owned `{name}-config` ConfigMap containing a fully rendered `authn.json`.
 - Operator-provisioned certificates via `tls.certificate` will include service external endpoints in the SAN list when using `externalAccess` options.
+- `spec.targetSpec.scaleDownMode` option to control target scale-down behavior. Defaults to `decommission` (rebalance data off the node, or delete it if rebalance is disabled); set to `retain` to keep data on the node via maintenance mode, for use when a replacement pod is expected to reschedule there immediately.
 
 ### Changed
 

--- a/operator/api/v1beta1/aistore_types.go
+++ b/operator/api/v1beta1/aistore_types.go
@@ -611,6 +611,19 @@ type DaemonSpec struct {
 	ExternalAccess *ExternalAccessSpec `json:"externalAccess,omitempty"`
 }
 
+// ScaleDownMode defines the behavior when scaling down targets.
+type ScaleDownMode string
+
+const (
+	// ScaleDownModeDecommission rebalances data off the node (or deletes it if
+	// rebalance is disabled) before removing the target.
+	ScaleDownModeDecommission ScaleDownMode = "decommission"
+	// ScaleDownModeRetain leaves data on the node by putting the target into
+	// maintenance mode. Useful when another pod is expected to be immediately
+	// scheduled; otherwise data may become inaccessible.
+	ScaleDownModeRetain ScaleDownMode = "retain"
+)
+
 // ProbeSpec defines optional overrides for Kubernetes probe timing parameters.
 // All fields are optional; unset fields use operator defaults.
 // SuccessThreshold is intentionally omitted: Kubernetes requires it to be 1 for liveness
@@ -661,6 +674,16 @@ type TargetSpec struct {
 	// during node drain or cluster scale-down operations by cloud providers.
 	// +optional
 	PodDisruptionBudget *PDBSpec `json:"pdb,omitempty"`
+
+	// ScaleDownMode controls how targets are scaled down.
+	// "decommission" (default) rebalances data off the node or deletes it, depending on whether rebalance is enabled.
+	// "retain" leaves data on the node by putting the target into maintenance mode. This is useful when you expect
+	// another pod to be immediately scheduled on the node. Note that if this is not the case then any data on the node
+	// will become inaccessible.
+	// +kubebuilder:validation:Enum=decommission;retain
+	// +kubebuilder:default:=decommission
+	// +optional
+	ScaleDownMode ScaleDownMode `json:"scaleDownMode,omitempty"`
 }
 
 // LogSidecarSpec defines a sidecar container to expose AIS logs to K8s
@@ -949,10 +972,6 @@ func (ais *AIStore) ShouldIncludeClientCert() bool {
 		return false
 	}
 	return tls.ClientAuthType(*ais.Spec.ConfigToUpdate.Net.HTTP.ClientAuthTLS) > tls.NoClientCert
-}
-
-func (ais *AIStore) IsFullyAutoScaling() bool {
-	return ais.GetTargetSize() == -1 && ais.GetProxySize() == -1
 }
 
 func (ais *AIStore) IsTargetAutoScaling() bool {

--- a/operator/api/v1beta1/aistore_webhook.go
+++ b/operator/api/v1beta1/aistore_webhook.go
@@ -291,6 +291,7 @@ func validateProxyUpdate(prev, ais *AIStore) error {
 func validateTargetUpdate(prev, ais *AIStore) error {
 	allowDaemonSpecUpdates(&prev.Spec.TargetSpec.DaemonSpec, &ais.Spec.TargetSpec.DaemonSpec)
 	prev.Spec.TargetSpec.PodDisruptionBudget = ais.Spec.TargetSpec.PodDisruptionBudget
+	prev.Spec.TargetSpec.ScaleDownMode = ais.Spec.TargetSpec.ScaleDownMode
 	if !equality.Semantic.DeepEqual(ais.Spec.TargetSpec, prev.Spec.TargetSpec) {
 		diff := deep.Equal(ais.Spec.TargetSpec, prev.Spec.TargetSpec)
 		webhooklog.Info(fmt.Sprintf("Differences found in target spec: [%s]", strings.Join(diff, ", ")))

--- a/operator/api/v1beta1/aistore_webhook_test.go
+++ b/operator/api/v1beta1/aistore_webhook_test.go
@@ -64,6 +64,13 @@ func TestValidateTargetUpdateTolerations(t *testing.T) {
 	})
 }
 
+func TestValidateTargetUpdateToScaleDownMode(t *testing.T) {
+	prev := &AIStore{}
+	ais := &AIStore{}
+	ais.Spec.TargetSpec.ScaleDownMode = "retain"
+	Expect(validateTargetUpdate(prev, ais)).To(Succeed())
+}
+
 func TestAIStoreValidateSize(t *testing.T) {
 	tests := []struct {
 		name       string // description of this test case

--- a/operator/config/base/crd/ais.nvidia.com_aistores.yaml
+++ b/operator/config/base/crd/ais.nvidia.com_aistores.yaml
@@ -5879,6 +5879,18 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scaleDownMode:
+                    default: decommission
+                    description: |-
+                      ScaleDownMode controls how targets are scaled down.
+                      "decommission" (default) rebalances data off the node or deletes it, depending on whether rebalance is enabled.
+                      "retain" leaves data on the node by putting the target into maintenance mode. This is useful when you expect
+                      another pod to be immediately scheduled on the node. Note that if this is not the case then any data on the node
+                      will become inaccessible.
+                    enum:
+                    - decommission
+                    - retain
+                    type: string
                   securityContext:
                     description: SecurityContext defines pod-level security attributes
                       and common container settings for AIS proxy and target pods.

--- a/operator/helm/ais-operator/templates/aistore-crd.yaml
+++ b/operator/helm/ais-operator/templates/aistore-crd.yaml
@@ -5867,6 +5867,18 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  scaleDownMode:
+                    default: decommission
+                    description: |-
+                      ScaleDownMode controls how targets are scaled down.
+                      "decommission" (default) rebalances data off the node or deletes it, depending on whether rebalance is enabled.
+                      "retain" leaves data on the node by putting the target into maintenance mode. This is useful when you expect
+                      another pod to be immediately scheduled on the node. Note that if this is not the case then any data on the node
+                      will become inaccessible.
+                    enum:
+                    - decommission
+                    - retain
+                    type: string
                   securityContext:
                     description: SecurityContext defines pod-level security attributes
                       and common container settings for AIS proxy and target pods.

--- a/operator/pkg/controllers/target_controllers.go
+++ b/operator/pkg/controllers/target_controllers.go
@@ -236,7 +236,7 @@ func (r *AIStoreReconciler) resolveStatefulSetScaling(ctx context.Context, ais *
 		}
 		logger.Info("Scaling up target statefulset to match AIS cluster spec size", "desiredSize", expectedSize)
 	} else if expectedSize < currentSize {
-		// Wait for decommission to complete before scaling the StatefulSet down
+		// If applicable, wait for decommission to complete before scaling the StatefulSet down
 		if ready, scaleErr := r.isReadyToScaleDown(ctx, ais, currentSize); scaleErr != nil || !ready {
 			return scaleErr
 		}
@@ -251,6 +251,10 @@ func (r *AIStoreReconciler) resolveStatefulSetScaling(ctx context.Context, ais *
 }
 
 func (r *AIStoreReconciler) isReadyToScaleDown(ctx context.Context, ais *aisv1.AIStore, currentSize int32) (ready bool, err error) {
+	if ais.Spec.TargetSpec.ScaleDownMode == aisv1.ScaleDownModeRetain {
+		return true, nil
+	}
+
 	logger := logf.FromContext(ctx)
 	apiClient, err := r.clientManager.GetClient(ctx, ais)
 	if err != nil {
@@ -282,23 +286,26 @@ func (r *AIStoreReconciler) startTargetScaling(ctx context.Context, ais *aisv1.A
 	}
 
 	// Otherwise - scale down.
-	// Ensure rebalance is enabled before decommissioning so data can migrate
-	// off the targets being decommissioned.
-	if err := r.enableRebalanceCondition(ctx, ais); err != nil {
-		return err
+	if ais.Spec.TargetSpec.ScaleDownMode == aisv1.ScaleDownModeDecommission {
+		// Ensure rebalance is enabled before decommissioning so data can migrate
+		// off the targets being decommissioned.
+		if err := r.enableRebalanceCondition(ctx, ais); err != nil {
+			return err
+		}
+		if err := r.handleConfigState(ctx, ais, true /*force*/); err != nil {
+			return err
+		}
 	}
-	if err := r.handleConfigState(ctx, ais, true /*force*/); err != nil {
-		return err
-	}
+
 	err := r.scaleDownLB(ctx, ais, ss)
 	if err != nil {
 		return err
 	}
-	// Decommission target through AIS API
-	return r.decommissionTargets(ctx, ais, *ss.Spec.Replicas)
+	// Prepare targets for scale down either via maintenance mode or decommission.
+	return r.prepareTargetsForScaleDown(ctx, ais, *ss.Spec.Replicas)
 }
 
-func (r *AIStoreReconciler) decommissionTargets(ctx context.Context, ais *aisv1.AIStore, actualSize int32) error {
+func (r *AIStoreReconciler) prepareTargetsForScaleDown(ctx context.Context, ais *aisv1.AIStore, actualSize int32) error {
 	logger := logf.FromContext(ctx)
 	apiClient, err := r.clientManager.GetClient(ctx, ais)
 	if err != nil {
@@ -308,10 +315,10 @@ func (r *AIStoreReconciler) decommissionTargets(ctx context.Context, ais *aisv1.
 	if err != nil {
 		return err
 	}
-	logger.Info("Decommissioning targets", "Smap version", smap)
+	logger.Info("Preparing targets for scale down", "Smap version", smap.Version)
 	for idx := actualSize; idx > ais.GetTargetSize(); idx-- {
 		podName := target.PodName(ais, idx-1)
-		logger.Info("Attempting to decommission target", "podName", podName)
+		logger.Info("Attempting to prepare target for scale down", "podName", podName)
 		node, err := findAISNodeByPodName(smap.Tmap, podName)
 		if err != nil {
 			// If target is not in the cluster map, fetch the pod and inspect state.
@@ -320,28 +327,37 @@ func (r *AIStoreReconciler) decommissionTargets(ctx context.Context, ais *aisv1.
 			pod, podErr := r.k8sClient.GetPod(ctx, types.NamespacedName{Name: podName, Namespace: ais.Namespace})
 			switch {
 			case k8serrors.IsNotFound(podErr):
-				logger.Info("Target pod not found, skipping decommission", "podName", podName)
+				logger.Info("Target pod not found, skipping scale-down preparation", "podName", podName)
 				continue
 			case podErr != nil:
 				return fmt.Errorf("failed to get pod %s: %w", podName, podErr)
 			case isPodUnschedulable(pod):
-				logger.Info("Target pod is unschedulable, skipping decommission", "podName", podName)
+				logger.Info("Target pod is unschedulable, skipping scale-down preparation", "podName", podName)
 				continue
 			case isPodInCrashLoopBackOff(pod):
-				logger.Info("Target pod is in CrashLoopBackOff, skipping decommission", "podName", podName)
+				logger.Info("Target pod is in CrashLoopBackOff, skipping scale-down preparation", "podName", podName)
 				continue
 			}
 			return fmt.Errorf("waiting for target %s to register in smap", podName)
 		}
 		if !smap.InMaintOrDecomm(node.ID()) {
-			logger.Info("Decommissioning target", "nodeID", node.ID())
-			_, err = apiClient.DecommissionNode(&aisapc.ActValRmNode{DaemonID: node.ID(), RmUserData: true})
-			if err != nil {
-				logger.Error(err, "Failed to decommission node", "nodeID", node.ID())
-				return err
+			if ais.Spec.TargetSpec.ScaleDownMode == aisv1.ScaleDownModeRetain {
+				logger.Info("Putting target in maintenance mode", "nodeID", node.ID())
+				_, err = apiClient.StartMaintenance(&aisapc.ActValRmNode{DaemonID: node.ID(), SkipRebalance: true})
+				if err != nil {
+					logger.Error(err, "Failed to put node in maintenance", "nodeID", node.ID())
+					return err
+				}
+			} else {
+				logger.Info("Decommissioning target", "nodeID", node.ID())
+				_, err = apiClient.DecommissionNode(&aisapc.ActValRmNode{DaemonID: node.ID(), RmUserData: true})
+				if err != nil {
+					logger.Error(err, "Failed to decommission node", "nodeID", node.ID())
+					return err
+				}
 			}
 		} else {
-			logger.Info("AIS target is already in decommissioning state", "nodeID", node.ID())
+			logger.Info("AIS target is already in maintenance or decommissioning state", "nodeID", node.ID())
 		}
 	}
 	return nil

--- a/operator/pkg/controllers/target_controllers_test.go
+++ b/operator/pkg/controllers/target_controllers_test.go
@@ -7,6 +7,8 @@ package controllers
 import (
 	"context"
 
+	"github.com/NVIDIA/aistore/api/apc"
+	aismeta "github.com/NVIDIA/aistore/core/meta"
 	aisv1 "github.com/ais-operator/api/v1beta1"
 	aisclient "github.com/ais-operator/pkg/client"
 	"github.com/ais-operator/pkg/resources/target"
@@ -14,8 +16,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/events"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -121,5 +125,174 @@ var _ = Describe("prepareTargetForRollout", func() {
 		requeue, err := r.prepareTargetForRollout(ctx, ais, podName)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(requeue).To(BeFalse())
+	})
+})
+
+var _ = Describe("scaleDownMode", func() {
+	var (
+		r         *AIStoreReconciler
+		ais       *aisv1.AIStore
+		mockCtrl  *gomock.Controller
+		apiClient *mocks.MockAIStoreClientInterface
+		namespace string
+		ctx       = context.TODO()
+	)
+
+	BeforeEach(func() {
+		namespace = "ais-test-" + rand.String(10)
+		Expect(k8sClient.Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}})).To(Succeed())
+
+		ais = &aisv1.AIStore{
+			ObjectMeta: metav1.ObjectMeta{Name: "ais", Namespace: namespace},
+			Spec: aisv1.AIStoreSpec{
+				InitImage: "init:latest",
+				NodeImage: "node:latest",
+				ProxySpec: aisv1.DaemonSpec{
+					Size: apc.Ptr[int32](1),
+					ServiceSpec: aisv1.ServiceSpec{
+						ServicePort:      intstr.FromInt32(51080),
+						PublicPort:       intstr.FromInt32(51081),
+						IntraControlPort: intstr.FromInt32(51082),
+						IntraDataPort:    intstr.FromInt32(51083),
+					},
+				},
+				TargetSpec: aisv1.TargetSpec{
+					DaemonSpec: aisv1.DaemonSpec{
+						Size: apc.Ptr[int32](2),
+						ServiceSpec: aisv1.ServiceSpec{
+							ServicePort:      intstr.FromInt32(51080),
+							PublicPort:       intstr.FromInt32(51081),
+							IntraControlPort: intstr.FromInt32(51082),
+							IntraDataPort:    intstr.FromInt32(51083),
+						},
+					},
+					Mounts: []aisv1.Mount{{Path: "/data"}},
+				},
+				StateStorage: &aisv1.StateStorage{
+					HostPath: &aisv1.StateHostPathConfig{Prefix: "/ais"},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ais)).To(Succeed())
+
+		tmpClient := aisclient.NewClient(k8sClient, k8sClient.Scheme())
+		mockCtrl = gomock.NewController(GinkgoT())
+		apiClient = mocks.NewMockAIStoreClientInterface(mockCtrl)
+		clientManager := mocks.NewMockAISClientManagerInterface(mockCtrl)
+		clientManager.EXPECT().GetClient(gomock.Any(), gomock.Any()).Return(apiClient, nil).AnyTimes()
+		r = NewAISReconciler(tmpClient, &events.FakeRecorder{}, ctrl.Log, clientManager)
+	})
+
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	makeSS := func(replicas int32) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			Spec: appsv1.StatefulSetSpec{
+				Replicas: &replicas,
+			},
+		}
+	}
+
+	Describe("isReadyToScaleDown", func() {
+		Context("when scaleDownMode is decommission (default)", func() {
+			It("scales when all targets are ready", func() {
+				t1 := &aismeta.Snode{DaeID: "t1", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-0"}}
+				t2 := &aismeta.Snode{DaeID: "t2", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-1"}}
+				smap := &aismeta.Smap{
+					Tmap: aismeta.NodeMap{"t1": t1, "t2": t2},
+				}
+				apiClient.EXPECT().GetClusterMap().Return(smap, nil)
+
+				// 2 targets in smap but currentSize is 3, so safe to scale down by 1.
+				ready, err := r.isReadyToScaleDown(ctx, ais, 3)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(BeTrue())
+			})
+
+			It("delays scaling when all targets are still active", func() {
+				t1 := &aismeta.Snode{DaeID: "t1", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-0"}}
+				t2 := &aismeta.Snode{DaeID: "t2", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-1"}}
+				t3 := &aismeta.Snode{DaeID: "t3", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-2"}}
+				smap := &aismeta.Smap{
+					Tmap: aismeta.NodeMap{"t1": t1, "t2": t2, "t3": t3},
+				}
+				apiClient.EXPECT().GetClusterMap().Return(smap, nil)
+
+				ready, err := r.isReadyToScaleDown(ctx, ais, 3)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(BeFalse())
+			})
+		})
+
+		Context("when scaleDownMode is retain", func() {
+			BeforeEach(func() {
+				ais.Spec.TargetSpec.ScaleDownMode = aisv1.ScaleDownModeRetain
+				Expect(k8sClient.Update(ctx, ais)).To(Succeed())
+			})
+
+			It("is always ready", func() {
+				ready, err := r.isReadyToScaleDown(ctx, ais, 3)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(ready).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("startTargetScaling", func() {
+		BeforeEach(func() {
+			// Pre-set rebalance condition so enableRebalanceCondition is a no-op
+			ais.SetCondition(aisv1.ConditionReadyRebalance)
+			Expect(k8sClient.Status().Update(ctx, ais)).To(Succeed())
+		})
+
+		Context("when scaleDownMode is decommission (default)", func() {
+			It("decommissions targets with RmUserData=true", func() {
+				ss := makeSS(3)
+
+				apiClient.EXPECT().SetClusterConfigUsingMsg(gomock.Any(), false).Return(nil)
+
+				t3 := &aismeta.Snode{DaeID: "t3", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-2"}}
+				smap := &aismeta.Smap{
+					Tmap: aismeta.NodeMap{"t3": t3},
+				}
+				apiClient.EXPECT().GetClusterMap().Return(smap, nil)
+
+				apiClient.EXPECT().DecommissionNode(gomock.Any()).DoAndReturn(func(act *apc.ActValRmNode) (string, error) {
+					Expect(act.RmUserData).To(BeTrue())
+					return "xid", nil
+				})
+
+				err := r.startTargetScaling(ctx, ais, ss)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when scaleDownMode is retain", func() {
+			BeforeEach(func() {
+				ais.Spec.TargetSpec.ScaleDownMode = aisv1.ScaleDownModeRetain
+				Expect(k8sClient.Update(ctx, ais)).To(Succeed())
+			})
+
+			It("puts targets in maintenance with SkipRebalance=true", func() {
+				ss := makeSS(3)
+
+				t3 := &aismeta.Snode{DaeID: "t3", DaeType: apc.Target, ControlNet: aismeta.NetInfo{Hostname: "ais-target-2"}}
+				smap := &aismeta.Smap{
+					Tmap: aismeta.NodeMap{"t3": t3},
+				}
+				apiClient.EXPECT().GetClusterMap().Return(smap, nil)
+
+				apiClient.EXPECT().StartMaintenance(gomock.Any()).DoAndReturn(func(act *apc.ActValRmNode) (string, error) {
+					Expect(act.SkipRebalance).To(BeTrue())
+					Expect(act.DaemonID).To(Equal("t3"))
+					return "xid", nil
+				})
+
+				err := r.startTargetScaling(ctx, ais, ss)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
 	})
 })


### PR DESCRIPTION
We run into issues currently in the following case:
* Nodes A and B are running target pods 0 and 1, respectively
* Node A has a hardware fault, so we drain and terminate it for repair. This leaves target pod 0 in a pending state since no node can host it.
* We scale down the AIStore cluster by 1 by setting `spec.size` in the CRD
* The operator decommissions target pod 1 and then deletes it
* Target pod 0 gets scheduled on node B, which was previously hosting target pod 1

This decommissioning causes some issues. If everything works well then it needlessly deletes all the data on node B. Target pod 0 is going to be immediately scheduled on node B and could have continued serving the files cached there. It's also possible for the decommission to fail partway through. This deletes some bucket directories and leaves some on the node. After target pod 0 is scheduled on the node, when trying to fetch a file from one of the deleted buckets, the request will fail with a 500 response code.

To address both cases, this adds a flag to skip decommissioning when scaling down either the proxy or target statefulsets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `spec.targetSpec.scaleDownMode` with two modes: `decommission` (default) and `retain`.
  * `retain` keeps data on nodes during scale down by placing targets into maintenance mode instead of decommissioning.
* **Bug Fixes**
  * Updated validation so CR updates that change only `scaleDownMode` are accepted.
  * Adjusted scale-down readiness and actions to follow the selected mode (including immediate readiness for `retain`).
* **Documentation**
  * Documented the new `scaleDownMode` field in the CRD/Helm schema and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->