### PR TITLE
operator: improved handling of node taints when autoscaling

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -17,6 +17,12 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
   - Applies optional container resource requirements, security context, and liveness/readiness probes to managed Deployments from `spec.deployment.container`.
   - Applies optional pod security context, node selector, tolerations, affinity, and image pull secrets to managed Deployments from `spec.deployment.pod`.
 
+
+### Changed
+
+- When autoscaling is enabled, the desired cluster size is now computed based on the union of (nodes where AIStore is currently running) and (nodes where AIStore is schedulable). This fixes an issue where marking a node unschedulable but not evicting the AIStore pods on it would cause the cluster to scale 
+down unnecessarily. Note that this will only take effect once a rollout to proxy and target statefulsets happens.
+
 ---
 
 ## v3.2.0

--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -17,11 +17,13 @@ import (
 	aisv1 "github.com/ais-operator/api/aistore/v1beta1"
 	authcontroller "github.com/ais-operator/internal/controller/aisauth"
 	aiscontroller "github.com/ais-operator/internal/controller/aistore"
+	"github.com/ais-operator/internal/resources/aistore/cmn"
 	"github.com/ais-operator/internal/services"
 	authwebhookv1alpha1 "github.com/ais-operator/internal/webhook/aisauth/v1alpha1"
 	aiswebhookv1beta1 "github.com/ais-operator/internal/webhook/aistore/v1beta1"
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -160,10 +162,17 @@ func main() {
 	mgrOptions := ctrl.Options{
 		Client: client.Options{
 			Cache: &client.CacheOptions{
-				// Disabling cache for Pods since `controller-runtime` is implicitly
-				// creating informer for Pods (after first GET/LIST) what in a large
-				// zones causes huge memory usage and may lead to OOM kills.
 				DisableFor: []client.Object{&corev1.Pod{}},
+			},
+		},
+		// Restrict the pod informer to only AIS pods (via the
+		// app.kubernetes.io/managed-by=ais-operator label) to avoid caching
+		// every pod in the cluster, which caused OOM kills in large zones.
+		Cache: cache.Options{
+			ByObject: map[client.Object]cache.ByObject{
+				&corev1.Pod{}: {
+					Label: labels.SelectorFromSet(labels.Set{cmn.LabelManagedBy: cmn.LabelManagedByValue}),
+				},
 			},
 		},
 		Scheme:                 scheme,

--- a/operator/internal/controller/aistore/cluster_controller.go
+++ b/operator/internal/controller/aistore/cluster_controller.go
@@ -203,23 +203,39 @@ func (r *Reconciler) determineAutoScaleStatus(ctx context.Context, ais *aisv1.AI
 	logger := logf.FromContext(ctx)
 	autoScaleStatus := aisv1.AutoScaleStatus{}
 	if ais.IsTargetAutoScaling() {
-		targetNodes, err := r.listMatchingNodeNames(ctx, ais.Spec.TargetSpec.NodeSelector, ais.Spec.TargetSpec.Tolerations)
+		schedulableNodes, err := r.listMatchingNodeNames(ctx, ais.Spec.TargetSpec.NodeSelector, ais.Spec.TargetSpec.Tolerations)
 		if err != nil {
 			logger.Error(err, "Unable to fetch nodes for autoScaleStatus target")
 			return err
 		}
-		logger.Info("Discovered autoScaleStatus target nodes", "targetNodes", targetNodes)
-		autoScaleStatus.ExpectedTargetNodes = targetNodes
+		podNodes, err := r.listNodesRunningDaemonPods(ctx, ais, target.SelectorLabels(ais))
+		if err != nil {
+			logger.Error(err, "Unable to fetch nodes running target pods for autoScaleStatus")
+			return err
+		}
+		// We include both nodes that are schedulable and nodes that currently contain AIStore pods to avoid unnecessary scale-downs
+		// when a node that's still running an AIStore pod becomes unschedulable.
+		unionNodes := unionSorted(schedulableNodes, podNodes)
+		logger.Info("Discovered autoScaleStatus target nodes", "targetNodes", unionNodes)
+		autoScaleStatus.ExpectedTargetNodes = unionNodes
 	}
 
 	if ais.IsProxyAutoScaling() {
-		proxyNodes, err := r.listMatchingNodeNames(ctx, ais.Spec.ProxySpec.NodeSelector, ais.Spec.ProxySpec.Tolerations)
+		schedulableNodes, err := r.listMatchingNodeNames(ctx, ais.Spec.ProxySpec.NodeSelector, ais.Spec.ProxySpec.Tolerations)
 		if err != nil {
 			logger.Error(err, "Unable to fetch nodes for autoScaleStatus proxy")
 			return err
 		}
-		logger.Info("Discovered autoScaleStatus proxy nodes", "proxyNodes", proxyNodes)
-		autoScaleStatus.ExpectedProxyNodes = proxyNodes
+		podNodes, err := r.listNodesRunningDaemonPods(ctx, ais, proxy.SelectorLabels(ais))
+		if err != nil {
+			logger.Error(err, "Unable to fetch nodes running proxy pods for autoScaleStatus")
+			return err
+		}
+		// We include both nodes that are schedulable and nodes that currently contain AIStore pods to avoid unnecessary scale-downs
+		// when a node that's still running an AIStore pod becomes unschedulable.
+		unionNodes := unionSorted(schedulableNodes, podNodes)
+		logger.Info("Discovered autoScaleStatus proxy nodes", "proxyNodes", unionNodes)
+		autoScaleStatus.ExpectedProxyNodes = unionNodes
 	}
 
 	return r.updateAutoScaleStatus(ctx, ais, autoScaleStatus)
@@ -1016,7 +1032,32 @@ func (r *Reconciler) patchStatus(ctx context.Context, ais *aisv1.AIStore) error 
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	nodePredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels())
+			if !reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+				return true
+			}
+
+			oldNode, ok1 := e.ObjectOld.(*corev1.Node)
+			newNode, ok2 := e.ObjectNew.(*corev1.Node)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return !reflect.DeepEqual(oldNode.Spec.Taints, newNode.Spec.Taints)
+		},
+		CreateFunc: func(_ event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool {
+			return true
+		},
+	}
+	podPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, ok1 := e.ObjectOld.(*corev1.Pod)
+			newPod, ok2 := e.ObjectNew.(*corev1.Pod)
+			if !ok1 || !ok2 {
+				return true
+			}
+			return oldPod.Spec.NodeName != newPod.Spec.NodeName
 		},
 		CreateFunc: func(_ event.CreateEvent) bool {
 			return true
@@ -1030,6 +1071,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Watches(&corev1.Node{},
 			handler.EnqueueRequestsFromMapFunc(r.findAISClustersForNode),
 			builder.WithPredicates(nodePredicate),
+		).
+		Watches(&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(r.findAISClustersForPod),
+			builder.WithPredicates(podPredicate),
 		).
 		Owns(&apiv1.StatefulSet{}).
 		Owns(&corev1.ConfigMap{}).
@@ -1089,6 +1134,25 @@ func (r *Reconciler) findAISClustersForNode(ctx context.Context, o k8sclient.Obj
 	}
 
 	return requests
+}
+
+func (r *Reconciler) findAISClustersForPod(_ context.Context, o k8sclient.Object) []reconcile.Request {
+	logger := r.log.WithName("pod-mapper").WithValues("object", o.GetName())
+
+	pod, ok := o.(*corev1.Pod)
+	if !ok {
+		logger.Error(fmt.Errorf("unexpected object type"), "Expected Pod", "got", fmt.Sprintf("%T", o))
+		return nil
+	}
+
+	aisName := pod.Labels[cmn.LabelAppPrefixed]
+	if aisName == "" {
+		return nil
+	}
+
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Namespace: pod.Namespace, Name: aisName},
+	}}
 }
 
 func (r *Reconciler) nodeMatchesForProxy(node *corev1.Node, ais *aisv1.AIStore) bool {
@@ -1153,6 +1217,44 @@ func (r *Reconciler) listMatchingNodeNames(ctx context.Context, selector map[str
 	}
 	slices.Sort(names)
 	return names, nil
+}
+
+// listNodesRunningDaemonPods returns the sorted names of nodes that currently
+// have an AIS daemon pod (matching the given labels) scheduled on them.
+func (r *Reconciler) listNodesRunningDaemonPods(ctx context.Context, ais *aisv1.AIStore, podLabels map[string]string) ([]string, error) {
+	modifiedPodLabels := make(map[string]string)
+	for key, value := range podLabels {
+		modifiedPodLabels[key] = value
+	}
+
+	// We add this label here so that the behavior change in https://github.com/NVIDIA/ais-k8s/pull/62 is fully backwards-compatible.
+	// That is, the autoscaling behavior won't change until a proxy + target statefulset rollout happens.
+	modifiedPodLabels[cmn.LabelManagedBy] = cmn.LabelManagedByValue
+
+	podList, err := r.k8sClient.ListPods(ctx, ais, modifiedPodLabels)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]struct{}, len(podList.Items))
+	for i := range podList.Items {
+		nodeName := podList.Items[i].Spec.NodeName
+		if nodeName != "" {
+			seen[nodeName] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names, nil
+}
+
+// unionSorted returns the sorted union of two string slices.
+func unionSorted(a, b []string) []string {
+	union := slices.Concat(a, b)
+	slices.Sort(union)
+	return slices.Compact(union)
 }
 
 // nodeAffectsTLSCertificate reports whether a change to node could change the

--- a/operator/internal/controller/aistore/common.go
+++ b/operator/internal/controller/aistore/common.go
@@ -222,10 +222,35 @@ func shouldUpdateAnnotations(desired, current *corev1.PodTemplateSpec) (bool, st
 }
 
 func shouldUpdateLabels(desired, current *corev1.PodTemplateSpec) (bool, string) {
-	if !equality.Semantic.DeepEqual(desired.Labels, current.Labels) {
-		return true, "updating labels"
+	if equality.Semantic.DeepEqual(desired.Labels, current.Labels) {
+		return false, ""
 	}
-	return false, ""
+	// Skip rollout when the sole difference is the operator adding its own
+	// managed-by label to pods that predate it. Existing pods won't be in
+	// the label-scoped informer cache until a future rollout applies the
+	// label, but that is preferable to restarting the whole cluster.
+	if onlyManagedByLabelAdded(desired.Labels, current.Labels) {
+		return false, ""
+	}
+	return true, "updating labels"
+}
+
+// onlyManagedByLabelAdded reports whether the sole difference between desired
+// and current labels is the addition of the managed-by label (absent in current).
+func onlyManagedByLabelAdded(desired, current map[string]string) bool {
+	if current[cmn.LabelManagedBy] == cmn.LabelManagedByValue {
+		return false
+	}
+	if desired[cmn.LabelManagedBy] != cmn.LabelManagedByValue {
+		return false
+	}
+	desiredCopy := make(map[string]string, len(desired))
+	for k, v := range desired {
+		if k != cmn.LabelManagedBy {
+			desiredCopy[k] = v
+		}
+	}
+	return equality.Semantic.DeepEqual(desiredCopy, current)
 }
 
 func shouldUpdateVolumes(desired, current *corev1.PodTemplateSpec) (bool, string) {

--- a/operator/internal/controller/aistore/common_test.go
+++ b/operator/internal/controller/aistore/common_test.go
@@ -732,6 +732,54 @@ var _ = Describe("syncContainers", func() {
 	})
 })
 
+var _ = Describe("shouldUpdateLabels", func() {
+	makePodTemplate := func(labels map[string]string) *corev1.PodTemplateSpec {
+		return &corev1.PodTemplateSpec{ObjectMeta: metav1.ObjectMeta{Labels: labels}}
+	}
+
+	It("returns false when labels are identical", func() {
+		labels := map[string]string{"app": "ais", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		update, _ := shouldUpdateLabels(makePodTemplate(labels), makePodTemplate(labels))
+		Expect(update).To(BeFalse())
+	})
+
+	It("returns false when the only difference is adding the managed-by label", func() {
+		desired := map[string]string{"app": "ais", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		current := map[string]string{"app": "ais"}
+		update, _ := shouldUpdateLabels(makePodTemplate(desired), makePodTemplate(current))
+		Expect(update).To(BeFalse())
+	})
+
+	It("returns true when a non-managed-by label changes", func() {
+		desired := map[string]string{"app": "ais", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		current := map[string]string{"app": "ais-old"}
+		update, reason := shouldUpdateLabels(makePodTemplate(desired), makePodTemplate(current))
+		Expect(update).To(BeTrue())
+		Expect(reason).To(Equal("updating labels"))
+	})
+
+	It("returns true when a non-managed-by label is added alongside managed-by", func() {
+		desired := map[string]string{"app": "ais", "env": "prod", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		current := map[string]string{"app": "ais"}
+		update, _ := shouldUpdateLabels(makePodTemplate(desired), makePodTemplate(current))
+		Expect(update).To(BeTrue())
+	})
+
+	It("returns true when managed-by value differs", func() {
+		desired := map[string]string{"app": "ais", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		current := map[string]string{"app": "ais", cmn.LabelManagedBy: "other-operator"}
+		update, _ := shouldUpdateLabels(makePodTemplate(desired), makePodTemplate(current))
+		Expect(update).To(BeTrue())
+	})
+
+	It("returns true when a label is removed and managed-by is added", func() {
+		desired := map[string]string{"app": "ais", cmn.LabelManagedBy: cmn.LabelManagedByValue}
+		current := map[string]string{"app": "ais", "old-label": "val"}
+		update, _ := shouldUpdateLabels(makePodTemplate(desired), makePodTemplate(current))
+		Expect(update).To(BeTrue())
+	})
+})
+
 var _ = Describe("shouldUpdateTolerations", func() {
 	makePodTemplate := func(tolerations []corev1.Toleration) *corev1.PodTemplateSpec {
 		pt := &corev1.PodTemplateSpec{}

--- a/operator/internal/resources/aistore/cmn/statefulset.go
+++ b/operator/internal/resources/aistore/cmn/statefulset.go
@@ -25,6 +25,8 @@ const (
 	LabelPrefix             = "app.kubernetes.io/"
 	LabelAppPrefixed        = LabelPrefix + "name"
 	LabelComponentPrefixed  = LabelPrefix + "component"
+	LabelManagedBy          = LabelPrefix + "managed-by"
+	LabelManagedByValue     = "ais-operator"
 	DefaultConfigStorageReq = int64(16 * aiscos.MiB)
 	DefaultLogsStorageReq   = int64(512 * aiscos.MiB)
 	DefaultMiscStorageReq   = int64(128 * aiscos.MiB)

--- a/operator/internal/resources/aistore/proxy/statefulset.go
+++ b/operator/internal/resources/aistore/proxy/statefulset.go
@@ -48,6 +48,7 @@ func DefaultPrimaryNSName(ais *aisv1.AIStore) types.NamespacedName {
 
 func NewProxyStatefulSet(ais *aisv1.AIStore, size int32) *apiv1.StatefulSet {
 	basicLabels := BasicLabels(ais)
+	basicLabels[cmn.LabelManagedBy] = cmn.LabelManagedByValue
 	podLabels := cmn.MergePodLabels(ais.Spec.ProxySpec.Labels, basicLabels)
 
 	ss := &apiv1.StatefulSet{

--- a/operator/internal/resources/aistore/target/statefulset.go
+++ b/operator/internal/resources/aistore/target/statefulset.go
@@ -40,6 +40,7 @@ func SelectorLabels(ais *aisv1.AIStore) map[string]string {
 
 func NewTargetSS(ais *aisv1.AIStore, expectedSize int32) *apiv1.StatefulSet {
 	basicLabels := BasicLabels(ais)
+	basicLabels[cmn.LabelManagedBy] = cmn.LabelManagedByValue
 	podLabels := cmn.MergePodLabels(ais.Spec.TargetSpec.Labels, basicLabels)
 
 	ss := &apiv1.StatefulSet{


### PR DESCRIPTION
We hit issues currently when modifying taints on nodes. For example, we may want to `kubectl cordon` a node to perform some debugging on it, run maintenance, etc. Right now the autoscaling behavior doesn't handle this super well. Say we have 3 nodes A, B, and C running target nodes:

A <-> target-0
B <-> target-1
C <-> target-2

then we run `kubectl cordon` on node B. target-1 keeps running since we didn't evict it, but the operator detects that the number of schedulable nodes is now 2 (only A and C) and scales down. This leaves a state like:

A <-> target-0
B (cordoned) <-> target-1
C empty

This fixes the issue by computing the desired size of the cluster as the union of (set of nodes currently running AIStore pods) and (set of nodes where AIStore pods are schedulable) when autoscaling is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved autoscaling to account for both schedulable nodes and nodes currently running AIStore workloads.
  * Added reconciliation when workload placement changes or node labels and taints are updated.
  * Added managed-by labels to AIStore target and proxy resources.

* **Bug Fixes**
  * Prevented unnecessary scale-down when nodes become unschedulable while still hosting AIStore pods.
  * Reduced cached pod data to relevant operator-managed workloads.

* **Documentation**
  * Updated the changelog with the autoscaling behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->