### PR TITLE
operator: scale down if proxy rollout is stuck

### DIFF
--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -24,12 +24,9 @@ We structure this changelog in accordance with [Keep a Changelog](https://keepac
 - AIStore TLS certificate SANs are now sorted and deduplicated before populating Certificate resources and CSI volume attributes.
 - Host state cleanup jobs now target a cluster's own scoped directory (`prefix/namespace/name`) instead of the shared hostpath prefix, so tearing down one cluster no longer removes state belonging to other clusters that might share the prefix.
 - Operator-managed admin clients now use the namespace's default ServiceAccount without mounting its token.
-
-
-### Changed
-
 - When autoscaling is enabled, the desired cluster size is now computed based on the union of (nodes where AIStore is currently running) and (nodes where AIStore is schedulable). This fixes an issue where marking a node unschedulable but not evicting the AIStore pods on it would cause the cluster to scale 
 down unnecessarily. Note that this will only take effect once a rollout to proxy and target statefulsets happens.
+- Detect the case where a proxy rollout is stuck due to an unschedulable pod and proxy scaling is needed, and perform the scaling before continuing with the rollout.
 
 ---
 

--- a/operator/internal/controller/aistore/proxy_controller.go
+++ b/operator/internal/controller/aistore/proxy_controller.go
@@ -143,12 +143,23 @@ func (r *Reconciler) handleProxyState(ctx context.Context, ais *aisv1.AIStore) (
 	rolloutNeeded, _ := shouldUpdatePodTemplate(&proxy.NewProxyStatefulSet(ais, ais.GetProxySize()).Spec.Template, &ss.Spec.Template)
 	scalingNeeded := isProxyScalingNeeded(ais, ss)
 
+	// Detect when a rollout is stuck on an unschedulable pod. If a pod is unschedulable then the rollout
+	// will be stuck, so we detect that and scale down the statefulset before continuing with the rollout.
+	rolloutBlocked := false
+	if rolling && ais.GetProxySize() < *ss.Spec.Replicas {
+		rolloutBlocked = r.hasUnschedulableProxyPods(ctx, ais)
+		if rolloutBlocked {
+			scalingNeeded = true
+		}
+	}
+
 	logger = logger.WithValues(
 		"statefulset", ss.Name,
 		"specReplicas", *ss.Spec.Replicas, "statusReplicas", ss.Status.Replicas,
 		"readyReplicas", ss.Status.ReadyReplicas, "desiredSize", ais.GetProxySize(),
 		"rolling", rolling, "scaling", scaling,
 		"rolloutNeeded", rolloutNeeded, "scalingNeeded", scalingNeeded,
+		"rolloutBlocked", rolloutBlocked,
 	)
 
 	// Apply template update (blocked by scaling in progress)
@@ -166,16 +177,17 @@ func (r *Reconciler) handleProxyState(ctx context.Context, ais *aisv1.AIStore) (
 		return ctrl.Result{RequeueAfter: statefulsetRequeueDelay}, nil
 	}
 
-	// Apply scaling (blocked by rollout in progress)
-	if scalingNeeded && !rolling {
-		proceed, cErr := r.confirmScalingNeeded(ctx, proxy.StatefulSetNSName(ais), ss,
-			ais.GetProxySize(), ais.GetProxyMaxUnavailable(), ais.IsProxyAutoScaling())
-		if cErr != nil {
-			return ctrl.Result{}, cErr
-		}
-		if !proceed {
-			logger.Info("Deferring proxy scale-down; fresh status shows unavailable replicas within maxUnavailable budget")
-			return ctrl.Result{RequeueAfter: proxyStartupInterval}, nil
+	if scalingNeeded && (!rolling || rolloutBlocked) {
+		if !rolloutBlocked {
+			proceed, cErr := r.confirmScalingNeeded(ctx, proxy.StatefulSetNSName(ais), ss,
+				ais.GetProxySize(), ais.GetProxyMaxUnavailable(), ais.IsProxyAutoScaling())
+			if cErr != nil {
+				return ctrl.Result{}, cErr
+			}
+			if !proceed {
+				logger.Info("Deferring proxy scale-down; fresh status shows unavailable replicas within maxUnavailable budget")
+				return ctrl.Result{RequeueAfter: proxyStartupInterval}, nil
+			}
 		}
 		if err = r.handleProxyScale(ctx, ais, ss); err != nil {
 			return ctrl.Result{}, err
@@ -199,6 +211,20 @@ func (r *Reconciler) handleProxyState(ctx context.Context, ais *aisv1.AIStore) (
 		return ctrl.Result{RequeueAfter: proxyStartupInterval}, nil
 	}
 	return
+}
+
+func (r *Reconciler) hasUnschedulableProxyPods(ctx context.Context, ais *aisv1.AIStore) bool {
+	podList, err := r.k8sClient.ListPods(ctx, ais, proxy.SelectorLabels(ais))
+	if err != nil {
+		logf.FromContext(ctx).Error(err, "Failed to list proxy pods")
+		return false
+	}
+	for i := range podList.Items {
+		if isPodUnschedulable(&podList.Items[i]) {
+			return true
+		}
+	}
+	return false
 }
 
 func isProxyScalingNeeded(ais *aisv1.AIStore, ss *appsv1.StatefulSet) bool {


### PR DESCRIPTION
Rollouts to the proxy statefulset currently become stuck if scaling becomes necessary in the middle of the rollout. For example, if a node is removed from the cluster during the rollout then a pod will be pending and the rollout will get stuck there.

This was fixed in v3.0.0 for target pods by not blocking the rollout on unschedulable pods, but this isn't possible for proxies because they use the default `RollingUpdate` update strategy of StatefulSets. Instead, we detect the case where a pod is unschedulable during a rollout and scaling is needed and perform the scaling before continuing with the rollout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved autoscaling desired cluster sizing by using the union of nodes where AIStore is running and nodes where it is schedulable.
  - Autoscaling updates now take effect only after completing rollout to the proxy and target statefulsets.
  - Enhanced detection of stalled proxy rollouts caused by unschedulable proxy pods during scale-down.
  - Proxy scaling will proceed when a rollout is blocked, helping prevent and reduce rollout delays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->