### PR TITLE
fix(state-manager): derive PVC names with removesuffix instead of rstrip

### DIFF
--- a/tools/state-manager/restore_runner.py
+++ b/tools/state-manager/restore_runner.py
@@ -66,7 +66,7 @@ class RestoreRunner:
         pvc_backup_files = self.pvc_backups.glob("*.tar.gz")
         desired_pvcs = []
         for backup in pvc_backup_files:
-            desired_pvcs.append(backup.name.rstrip(".tar.gz"))
+            desired_pvcs.append(backup.name.removesuffix(".tar.gz"))
         # If we have all, we're done
         if set(pvcs) == set(desired_pvcs):
             print(f"Found PVCs matching restore files: {pvcs}")

--- a/tools/state-manager/test_restore_runner.py
+++ b/tools/state-manager/test_restore_runner.py
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+#
+"""
+Unit tests for RestoreRunner.validate_pvcs (no cluster required).
+
+Regression coverage for the rstrip-vs-suffix bug: PVC names must be derived
+from backup filenames by removing the ".tar.gz" suffix, not by stripping the
+character set ".targz" (which mangles names like "ais-target" -> "ais-targe").
+
+Run from tools/state-manager:
+    python3 -m unittest test_restore_runner -v
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+# Stub out the kubernetes client and pod_config imports (cluster-only deps).
+# The V1* factories return plain namespaces so manifests keep their fields.
+_k8s_stub = mock.MagicMock()
+_k8s_stub.client.V1ObjectMeta.side_effect = (
+    lambda name=None, labels=None: SimpleNamespace(name=name, labels=labels)
+)
+_k8s_stub.client.V1PersistentVolumeClaim.side_effect = (
+    lambda metadata=None, spec=None: SimpleNamespace(metadata=metadata, spec=spec)
+)
+sys.modules.setdefault("kubernetes", _k8s_stub)
+sys.modules.setdefault("pod_config", mock.MagicMock())
+
+from restore_runner import RestoreRunner  # noqa: E402  pylint: disable=wrong-import-position
+
+
+class TestRestoreRunnerValidatePvcs(unittest.TestCase):
+    """PVC-name derivation from per-PVC backup filenames."""
+
+    def _make_runner(self, pvc_backups: Path, existing_pvcs=None) -> RestoreRunner:
+        manager = mock.MagicMock()
+        manager.find_pvcs.return_value = existing_pvcs or []
+        with mock.patch.object(
+            RestoreRunner, "init_pvc_backups_dir", return_value=pvc_backups
+        ):
+            return RestoreRunner(manager, Path("dummy.tar.gz"), mock.MagicMock())
+
+    def test_derives_pvc_names_by_suffix_removal(self):
+        """Names ending in .targz characters must survive suffix removal."""
+        backups = [
+            "ais-target.tar.gz",
+            "ais-proxy.tar.gz",
+            "ais-target-state.tar.gz",
+            "my-config.tar.gz",
+            "data-tag.tar.gz",
+        ]
+        expected = sorted(
+            ["ais-target", "ais-proxy", "ais-target-state", "my-config", "data-tag"]
+        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backup_dir = Path(tmpdir)
+            for name in backups:
+                backup_dir.joinpath(name).touch()
+            runner = self._make_runner(backup_dir)
+            desired = runner.validate_pvcs()
+
+        self.assertEqual(sorted(desired), expected)
+        # No existing PVCs -> exactly the desired set must be created
+        created = [
+            c.args[0].metadata.name for c in runner.manager.create_pvc.call_args_list
+        ]
+        self.assertEqual(sorted(created), expected)
+
+    def test_matching_existing_pvcs_are_accepted(self):
+        """Existing PVCs matching the restore file skip creation."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            backup_dir = Path(tmpdir)
+            backup_dir.joinpath("ais-target.tar.gz").touch()
+            runner = self._make_runner(backup_dir, existing_pvcs=["ais-target"])
+            desired = runner.validate_pvcs()
+
+        self.assertEqual(desired, ["ais-target"])
+        runner.manager.create_pvc.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/state-manager/test_restore_runner.py
+++ b/tools/state-manager/test_restore_runner.py
@@ -19,31 +19,56 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest import mock
 
-# Stub out the kubernetes client and pod_config imports (cluster-only deps).
-# The V1* factories return plain namespaces so manifests keep their fields.
-_k8s_stub = mock.MagicMock()
-_k8s_stub.client.V1ObjectMeta.side_effect = (
-    lambda name=None, labels=None: SimpleNamespace(name=name, labels=labels)
-)
-_k8s_stub.client.V1PersistentVolumeClaim.side_effect = (
-    lambda metadata=None, spec=None: SimpleNamespace(metadata=metadata, spec=spec)
-)
-sys.modules.setdefault("kubernetes", _k8s_stub)
-sys.modules.setdefault("pod_config", mock.MagicMock())
 
-from restore_runner import RestoreRunner  # noqa: E402  pylint: disable=wrong-import-position
+def _make_k8s_stub():
+    """Return a MagicMock pre-configured with V1* factories."""
+    stub = mock.MagicMock()
+    stub.client.V1ObjectMeta.side_effect = (
+        lambda name=None, labels=None: SimpleNamespace(name=name, labels=labels)
+    )
+    stub.client.V1PersistentVolumeClaim.side_effect = (
+        lambda metadata=None, spec=None: SimpleNamespace(metadata=metadata, spec=spec)
+    )
+    return stub
 
 
 class TestRestoreRunnerValidatePvcs(unittest.TestCase):
     """PVC-name derivation from per-PVC backup filenames."""
 
-    def _make_runner(self, pvc_backups: Path, existing_pvcs=None) -> RestoreRunner:
+    def setUp(self):
+        # Stub cluster-only deps inside a temporary patch so they cannot leak
+        # into other tests. Preserve any pre-existing module cache entries.
+        self._k8s_stub = _make_k8s_stub()
+        self._pod_config_stub = mock.MagicMock()
+        self._module_patcher = mock.patch.dict(
+            sys.modules,
+            {
+                "kubernetes": self._k8s_stub,
+                "pod_config": self._pod_config_stub,
+            },
+        )
+        self._module_patcher.start()
+        # Drop any cached restore_runner so the import below sees the stubs.
+        self._prior_restore_runner = sys.modules.pop("restore_runner", None)
+
+        from restore_runner import RestoreRunner  # noqa: E402  pylint: disable=wrong-import-position
+
+        self.RestoreRunner = RestoreRunner
+
+    def tearDown(self):
+        self._module_patcher.stop()
+        # Restore any prior restore_runner cache entry.
+        sys.modules.pop("restore_runner", None)
+        if self._prior_restore_runner is not None:
+            sys.modules["restore_runner"] = self._prior_restore_runner
+
+    def _make_runner(self, pvc_backups: Path, existing_pvcs=None):
         manager = mock.MagicMock()
         manager.find_pvcs.return_value = existing_pvcs or []
         with mock.patch.object(
-            RestoreRunner, "init_pvc_backups_dir", return_value=pvc_backups
+            self.RestoreRunner, "init_pvc_backups_dir", return_value=pvc_backups
         ):
-            return RestoreRunner(manager, Path("dummy.tar.gz"), mock.MagicMock())
+            return self.RestoreRunner(manager, Path("dummy.tar.gz"), mock.MagicMock())
 
     def test_derives_pvc_names_by_suffix_removal(self):
         """Names ending in .targz characters must survive suffix removal."""

--- a/tools/state-manager/test_restore_runner.py
+++ b/tools/state-manager/test_restore_runner.py
@@ -12,15 +12,21 @@ Run from tools/state-manager:
     python3 -m unittest test_restore_runner -v
 """
 
+from __future__ import annotations
+
 import sys
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest import mock
 
+if TYPE_CHECKING:
+    from restore_runner import RestoreRunner
 
-def _make_k8s_stub():
+
+def _make_k8s_stub() -> mock.MagicMock:
     """Return a MagicMock pre-configured with V1* factories."""
     stub = mock.MagicMock()
     stub.client.V1ObjectMeta.side_effect = (
@@ -48,21 +54,24 @@ class TestRestoreRunnerValidatePvcs(unittest.TestCase):
             },
         )
         self._module_patcher.start()
+        # Ensure cleanup runs even if the import below raises.
+        self.addCleanup(self._module_patcher.stop)
+
         # Drop any cached restore_runner so the import below sees the stubs.
         self._prior_restore_runner = sys.modules.pop("restore_runner", None)
+        self.addCleanup(self._restore_prior_module)
 
         from restore_runner import RestoreRunner  # noqa: E402  pylint: disable=wrong-import-position
 
         self.RestoreRunner = RestoreRunner
 
-    def tearDown(self):
-        self._module_patcher.stop()
-        # Restore any prior restore_runner cache entry.
+    def _restore_prior_module(self):
+        """Restore the previous restore_runner module cache entry, if any."""
         sys.modules.pop("restore_runner", None)
         if self._prior_restore_runner is not None:
             sys.modules["restore_runner"] = self._prior_restore_runner
 
-    def _make_runner(self, pvc_backups: Path, existing_pvcs=None):
+    def _make_runner(self, pvc_backups: Path, existing_pvcs=None) -> RestoreRunner:
         manager = mock.MagicMock()
         manager.find_pvcs.return_value = existing_pvcs or []
         with mock.patch.object(


### PR DESCRIPTION
## Summary

The `restore` action of the state-manager tool computes desired PVC names from extracted per-PVC backup filenames (`<pvc>.tar.gz`). For any PVC name ending in one of the characters `.targz` — e.g. the extremely common `ais-target.tar.gz` — the derived name is silently mangled (`ais-target` becomes `ais-targe`). The restore then either aborts with "Found non-zero existing PVCs not matching restore file" or, on a fresh namespace, creates and restores into wrongly-named PVCs that the AIS deployment will not mount.

## Root cause

```python
desired_pvcs.append(backup.name.rstrip(".tar.gz"))
```

`str.rstrip()` takes a *set of characters*, not a suffix. It strips ".tar.gz" and then keeps stripping any trailing `.`, `t`, `a`, `r`, `g`, `z` characters from the PVC name itself:

| backup file             | rstrip (before) | removesuffix (after) |
|-------------------------|-----------------|----------------------|
| ais-target.tar.gz       | ais-targe       | ais-target           |
| my-config.tar.gz        | my-confi        | my-config            |
| data-tag.tar.gz         | data-           | data-tag             |
| ais-proxy.tar.gz        | ais-proxy       | ais-proxy            |

## Fix

```python
desired_pvcs.append(backup.name.removesuffix(".tar.gz"))
```

(removesuffix requires Python 3.9+; the tool's pinned kubernetes==32.0.1 client already requires >=3.9.)

## Testing

No automated tests exist for tools/state-manager (it drives a live k8s cluster via the Python client and kubectl).

Smoke test stubbing the `kubernetes`/`pod_config` imports and calling `RestoreRunner.validate_pvcs()` against a temp `restore/pvc_backups/` dir containing `ais-target.tar.gz`, `ais-proxy.tar.gz`, `ais-target-state.tar.gz` with no existing PVCs:

- with fix: desired/created PVCs = ['ais-proxy', 'ais-target', 'ais-target-state'] — PASS
- with fix stashed (unmodified code): desired = ['ais-targe', ...] — FAIL, confirming the bug and that the fix resolves it

## Why existing tests missed it

tools/state-manager has no unit tests; the bug only manifests for PVC names ending in `.targz` characters, which never occurs in ad-hoc manual testing with names like `*-proxy` or `*-state`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected restored PVC name derivation from backup filenames ending in `.tar.gz` to remove the exact suffix, preventing incorrect truncation.
* **Tests**
  * Added standalone unit tests for restore PVC validation that run without a Kubernetes cluster by stubbing imports, including coverage for `.tar.gz` handling and ensuring PVC creation is skipped when matching PVCs already exist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->